### PR TITLE
Fix tool name sanitization and document image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,62 @@ Log files are stored in `~/.local/share/opencode/logs/` (or `$XDG_DATA_HOME/open
 
 ## Troubleshooting
 
+### Image Support
+
+To enable image input for Antigravity models in OpenCode, you must add the `modalities` configuration to your model definitions in `opencode.json`:
+
+```json
+{
+  "provider": {
+    "google": {
+      "models": {
+        "gemini-3-pro-high": {
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        },
+        "claude-sonnet-4-5-thinking": {
+          "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Without the `modalities.input` array containing `"image"`, OpenCode will reject image inputs with the error: `"this model does not support image input"`. This applies to both Gemini and Claude models accessed through Antigravity.
+
+**Note:** The example config in this README already includes proper `modalities` configuration for all models.
+
+### Tool Name Compatibility with Gemini
+
+Gemini API requires tool names to match the pattern `^[a-zA-Z_][a-zA-Z0-9_-]*$`, meaning they cannot start with numbers. The plugin automatically sanitizes tool names by prepending `t_` to any tool name that starts with a digit.
+
+For example:
+- `21st-dev-magic_component_builder` → `t_21st-dev-magic_component_builder`
+
+This sanitization is transparent and automatic. However, if you encounter tool-related errors with Gemini models, you can disable problematic MCP servers in your config:
+
+```json
+{
+  "provider": {
+    "google": {
+      "models": {
+        "gemini-3-pro-high": {
+          "tools": {
+            "21st-dev-magic_*": false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ### Compatibility with `opencode-skills`
 
 The [`opencode-skills`](https://github.com/malhashemi/opencode-skills) plugin is currently **incompatible** with this plugin. Using them together may cause `invalid_request_error` failures, especially with Claude thinking models, due to conflicts in message history handling.


### PR DESCRIPTION
## Summary

This PR fixes two important issues with the Antigravity plugin:

1. **Tool Name Sanitization**: Gemini API rejects tool names starting with numbers (e.g., `21st-dev-magic_*`). This PR adds automatic sanitization by prepending `t_` to numeric-prefixed tool names.

2. **Image Support Documentation**: Documents the requirement to add `modalities.input: ["text", "image"]` to model configs in `opencode.json` for image support to work.

## Changes

### Code Changes
- **`src/plugin/transform/gemini.ts`**:
  - Added `sanitizeToolNameForGemini()` function to prepend `t_` to tool names starting with digits
  - Added `sanitizeToolNames()` function to apply sanitization to all tools in the request payload
  - Integrated sanitization into the `transformGeminiRequest()` flow
  - Added debug logging when tool names are sanitized

### Documentation Changes
- **`README.md`**:
  - Added new "Image Support" troubleshooting section explaining the `modalities` requirement
  - Added "Tool Name Compatibility with Gemini" section documenting the automatic sanitization
  - Included config examples for both fixes
  - Noted that the example config already includes proper `modalities` configuration

## Problem Details

### Tool Name Validation Error
Gemini API requires tool names to match `^[a-zA-Z_][a-zA-Z0-9_-]*$`. MCP servers like `21st-dev-magic` have tools that start with numbers, causing validation failures:
```
invalid_request_error: [{'@type': 'type.googleapis.com/google.rpc.BadRequest', 'fieldViolations': [{'field': 'tools[0].function_declarations[0].name', 'description': "Invalid name: '21st-dev-magic_21st_magic_component_builder'. Names must start with a letter or underscore..."}]}]
```

### Image Support Error
OpenCode checks model capabilities before sending images. Without `modalities.input` containing `"image"`, users get:
```
this model does not support image input
```

Even though Antigravity models DO support images, the OpenCode config needs to declare this capability.

## Testing

Both fixes have been tested and verified working:
- ✅ Tool names starting with numbers are automatically sanitized
- ✅ Images can be pasted and processed after adding `modalities` config
- ✅ Works with both Gemini and Claude models via Antigravity

## Backward Compatibility

- **Tool sanitization**: Fully backward compatible, transparent to users
- **Image config**: Requires users to update their `opencode.json`, but the example config in README is updated

## Related Issues

Fixes issues where:
- MCP servers with numeric prefixes caused validation errors with Gemini models
- Image pasting failed despite models having multimodal capabilities