### PR TITLE
fix: use schema-aware normalization for tool call arguments

### DIFF
--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -8,6 +8,7 @@ import {
   generateRequestId,
   getSessionId,
   parseGeminiApiBody,
+  normalizeToolCallArgs,
   recursivelyParseJsonStrings,
   rewriteGeminiPreviewAccessError,
   rewriteGeminiRateLimitError,
@@ -321,7 +322,7 @@ function normalizeToolArgsInResponse(response: unknown): void {
       const functionCall = (part as any)?.functionCall;
       if (functionCall && "args" in functionCall) {
         const beforeArgs = functionCall.args;
-        const afterArgs = recursivelyParseJsonStrings(beforeArgs);
+        const afterArgs = normalizeToolCallArgs(beforeArgs, functionCall.name);
         functionCall.args = afterArgs;
 
         if (typeof beforeArgs === "string" && beforeArgs !== afterArgs) {

--- a/src/plugin/tool-schema-cache.ts
+++ b/src/plugin/tool-schema-cache.ts
@@ -1,0 +1,94 @@
+
+/**
+ * Info about a tool parameter schema.
+ */
+export type SchemaInfo = {
+  type: string;
+  items?: SchemaInfo;
+  properties?: Record<string, SchemaInfo>;
+};
+
+/**
+ * Cache structure: Map<toolName, Map<paramName, SchemaInfo>>
+ */
+const toolSchemaCache = new Map<string, Map<string, SchemaInfo>>();
+
+/**
+ * Sanitizes tool names for Gemini API compatibility.
+ * This should match the logic in gemini.ts.
+ */
+function sanitizeToolName(name: string): string {
+  if (/^[0-9]/.test(name)) {
+    return `t_${name}`;
+  }
+  return name;
+}
+
+/**
+ * Recursively extracts schema info from a JSON schema object.
+ */
+function extractSchemaInfo(schema: any): SchemaInfo {
+  const type = schema?.type || "unknown";
+  const info: SchemaInfo = { type };
+
+  if (type === "array" && schema.items) {
+    info.items = extractSchemaInfo(schema.items);
+  } else if (type === "object" && schema.properties) {
+    info.properties = {};
+    for (const [key, value] of Object.entries(schema.properties)) {
+      info.properties[key] = extractSchemaInfo(value);
+    }
+  }
+
+  return info;
+}
+
+/**
+ * Caches tool schemas from a request payload.
+ */
+export function cacheToolSchemas(tools: any[] | undefined): void {
+  if (!Array.isArray(tools)) return;
+
+  for (const tool of tools) {
+    const funcDecls = tool.functionDeclarations;
+    if (!Array.isArray(funcDecls)) continue;
+
+    for (const funcDecl of funcDecls) {
+      const originalName = funcDecl.name;
+      if (typeof originalName !== "string") continue;
+
+      const sanitizedName = sanitizeToolName(originalName);
+      const schema = (funcDecl.parametersJsonSchema ?? funcDecl.parameters) as any;
+      
+      if (!schema || typeof schema !== "object") continue;
+
+      const properties = schema.properties;
+      if (!properties || typeof properties !== "object") continue;
+
+      const paramMap = new Map<string, SchemaInfo>();
+      for (const [paramName, paramSchema] of Object.entries(properties)) {
+        paramMap.set(paramName, extractSchemaInfo(paramSchema));
+      }
+      
+      toolSchemaCache.set(sanitizedName, paramMap);
+      // Also cache with original name to be safe
+      if (sanitizedName !== originalName) {
+        toolSchemaCache.set(originalName, paramMap);
+      }
+    }
+  }
+}
+
+/**
+ * Gets the expected type for a tool parameter.
+ */
+export function getParamType(toolName: string, paramName: string): string | undefined {
+  return toolSchemaCache.get(toolName)?.get(paramName)?.type;
+}
+
+/**
+ * Clears the tool schema cache.
+ */
+export function clearToolSchemaCache(): void {
+  toolSchemaCache.clear();
+}

--- a/src/plugin/transform/claude.ts
+++ b/src/plugin/transform/claude.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { cacheSignature, getCachedSignature } from "../cache";
 import { createLogger } from "../logger";
 import { normalizeThinkingConfig } from "../request-helpers";
+import { cacheToolSchemas } from "../tool-schema-cache";
 import type { RequestPayload, TransformContext, TransformResult } from "./types";
 
 const log = createLogger("transform.claude");
@@ -186,6 +187,9 @@ export function transformClaudeRequest(
   if ("model" in requestPayload) {
     delete requestPayload.model;
   }
+
+  // Cache tool schemas for response normalization
+  cacheToolSchemas(requestPayload.tools as any[]);
 
   const tools = requestPayload.tools as Array<Record<string, unknown>> | undefined;
   if (Array.isArray(tools)) {

--- a/src/plugin/transform/gemini.ts
+++ b/src/plugin/transform/gemini.ts
@@ -1,6 +1,7 @@
 import { getCachedSignature } from "../cache";
 import { createLogger } from "../logger";
 import { normalizeThinkingConfig } from "../request-helpers";
+import { cacheToolSchemas } from "../tool-schema-cache";
 import type { RequestPayload, TransformContext, TransformResult } from "./types";
 
 const log = createLogger("transform.gemini");
@@ -515,6 +516,9 @@ export function transformGeminiRequest(
 
   // Sanitize tool names to ensure Gemini API compatibility
   sanitizeToolNames(requestPayload);
+
+  // Cache tool schemas for response normalization
+  cacheToolSchemas(requestPayload.tools as any[]);
 
   augmentToolDescriptionsWithStrictParams(requestPayload);
   injectSystemInstructionIfNeeded(requestPayload);


### PR DESCRIPTION
This fixes the issue where JSON-formatted string parameters (like the 'content' field in the 'write' tool) were incorrectly parsed into objects, causing OpenCode validation to fail with 'expected string, received object'.

The fix introduces a tool schema cache that stores parameter type information during request transformation. When normalizing tool call arguments in responses, the new normalizeToolCallArgs function:

- Preserves string parameters as-is (only processing escape sequences)
- Parses JSON strings only when the schema expects array/object types
- Falls back to conservative behavior when schema info is unavailable

This affects both Gemini and Claude models.

Fixes #11 