### PR TITLE
fix(antigravity): update handling for new Antigravity API structure

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,15 +1,16 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-gemini-auth",
       "dependencies": {
         "@openauthjs/openauth": "^0.4.3",
-        "@opencode-ai/plugin": "^1.0.169",
+        "@opencode-ai/plugin": "^1.0.182",
         "open": "^11.0.0",
       },
       "devDependencies": {
-        "@opencode-ai/sdk": "^1.0.169",
+        "@opencode-ai/sdk": "^1.0.182",
         "@types/bun": "latest",
       },
       "peerDependencies": {

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -132,6 +132,20 @@ describe("URL Transformation", () => {
     
     expect(result.requestedModel).toBe("gemini-3-flash");
   });
+
+  test("aliases gemini-3-flash-preview to gemini-3-flash", async () => {
+    const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent";
+
+    const result = await prepareAntigravityRequest(
+      url,
+      { method: "POST", body: JSON.stringify({ contents: [] }) },
+      "dummy-token",
+      "dummy-project"
+    );
+
+    const body = JSON.parse(result.init.body as string);
+    expect(body.model).toBe("gemini-3-flash");
+  });
 });
 
 describe("Endpoint Fallback Override", () => {

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -29,6 +29,7 @@ const MODEL_ALIASES: Record<string, string> = {
   "gemini-2.5-computer-use-preview-10-2025": "rev19-uic3-1p",
   "gemini-3-pro-image-preview": "gemini-3-pro-image",
   "gemini-3-pro-preview": "gemini-3-pro-high",
+  "gemini-3-flash-preview": "gemini-3-flash",
   "gemini-claude-sonnet-4-5": "claude-sonnet-4-5",
   "gemini-claude-sonnet-4-5-thinking": "claude-sonnet-4-5-thinking",
   "gemini-claude-opus-4-5-thinking": "claude-opus-4-5-thinking",

--- a/src/plugin/transform/claude.ts
+++ b/src/plugin/transform/claude.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { cacheSignature, getCachedSignature } from "../cache";
 import { createLogger } from "../logger";
-import { normalizeThinkingConfig } from "../request-helpers";
+import { applyAntigravitySystemInstruction, normalizeThinkingConfig } from "../request-helpers";
 import { cacheToolSchemas } from "../tool-schema-cache";
 import type { RequestPayload, TransformContext, TransformResult } from "./types";
 
@@ -161,6 +161,8 @@ export function transformClaudeRequest(
     delete requestPayload.system_instruction;
   }
 
+  applyAntigravitySystemInstruction(requestPayload, context.model);
+
   const cachedContentFromExtra =
     typeof requestPayload.extra_body === "object" && requestPayload.extra_body
       ? (requestPayload.extra_body as Record<string, unknown>).cached_content ??
@@ -316,6 +318,7 @@ export function transformClaudeRequest(
     project: context.projectId,
     model: context.model,
     userAgent: "antigravity",
+    requestType: "agent",
     requestId: context.requestId,
     request: requestPayload,
   };

--- a/src/plugin/transform/gemini.ts
+++ b/src/plugin/transform/gemini.ts
@@ -1,6 +1,6 @@
 import { getCachedSignature } from "../cache";
 import { createLogger } from "../logger";
-import { normalizeThinkingConfig } from "../request-helpers";
+import { applyAntigravitySystemInstruction, normalizeThinkingConfig } from "../request-helpers";
 import { cacheToolSchemas } from "../tool-schema-cache";
 import type { RequestPayload, TransformContext, TransformResult } from "./types";
 
@@ -531,6 +531,7 @@ export function transformGeminiRequest(
   augmentToolDescriptionsWithStrictParams(requestPayload);
   injectSystemInstructionIfNeeded(requestPayload);
   scrubConversationArtifactsFromModelHistory(requestPayload);
+  applyAntigravitySystemInstruction(requestPayload, context.model);
 
   const contents = requestPayload.contents as Array<Record<string, unknown>> | undefined;
   if (Array.isArray(contents)) {
@@ -638,6 +639,7 @@ export function transformGeminiRequest(
     project: context.projectId,
     model: context.model,
     userAgent: "antigravity",
+    requestType: "agent",
     requestId: context.requestId,
     request: requestPayload,
   };


### PR DESCRIPTION
## Summary
- antigravity’s backend now expects a specific systemInstruction structure; missing it causes proxy requests to fail (see https://github.com/router-for-me/CLIProxyAPI/issues/903).
- this PR injects the required Antigravity base systemInstruction and requestType: "agent" so requests match the new API format.
- alias gemini-3-flash-preview to gemini-3-flash
- add regression coverage for the updated request handling

## Testing
- bun test src/plugin/transform/signature.test.ts src/plugin/request.test.ts