### PR TITLE
feat(antigravity): add session recovery for thinking block errors

### DIFF
--- a/src/plugin/recovery/constants.ts
+++ b/src/plugin/recovery/constants.ts
@@ -1,0 +1,20 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+function getXdgData(): string {
+  const platform = process.platform;
+
+  if (platform === "win32") {
+    return process.env.APPDATA || join(homedir(), "AppData", "Roaming");
+  }
+
+  return process.env.XDG_DATA_HOME || join(homedir(), ".local", "share");
+}
+
+export const OPENCODE_STORAGE = join(getXdgData(), "opencode", "storage");
+export const MESSAGE_STORAGE = join(OPENCODE_STORAGE, "message");
+export const PART_STORAGE = join(OPENCODE_STORAGE, "part");
+
+export const THINKING_TYPES = new Set(["thinking", "redacted_thinking", "reasoning"]);
+export const META_TYPES = new Set(["step-start", "step-finish"]);
+export const CONTENT_TYPES = new Set(["text", "tool", "tool_use", "tool_result"]);

--- a/src/plugin/recovery/index.ts
+++ b/src/plugin/recovery/index.ts
@@ -1,0 +1,223 @@
+import { createLogger } from "../logger";
+import type { PluginClient } from "../types";
+import {
+  readParts,
+  findMessagesWithOrphanThinking,
+  findMessageByIndexNeedingThinking,
+  prependThinkingPart,
+} from "./storage";
+import type { MessageInfo, MessageData, RecoveryErrorType } from "./types";
+
+const log = createLogger("session-recovery");
+
+const RECOVERY_RESUME_TEXT = "[session recovered - continuing previous task]";
+
+function getErrorMessage(error: unknown): string {
+  if (!error) return "";
+  if (typeof error === "string") return error.toLowerCase();
+
+  const errorObj = error as Record<string, unknown>;
+  const paths = [
+    errorObj.data,
+    errorObj.error,
+    errorObj,
+    (errorObj.data as Record<string, unknown>)?.error,
+  ];
+
+  for (const obj of paths) {
+    if (obj && typeof obj === "object") {
+      const msg = (obj as Record<string, unknown>).message;
+      if (typeof msg === "string" && msg.length > 0) {
+        return msg.toLowerCase();
+      }
+    }
+  }
+
+  try {
+    return JSON.stringify(error).toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function extractMessageIndex(error: unknown): number | null {
+  const message = getErrorMessage(error);
+  const match = message.match(/messages\.(\d+)/);
+  if (!match || !match[1]) return null;
+  return parseInt(match[1], 10);
+}
+
+export function detectErrorType(error: unknown): RecoveryErrorType | null {
+  const message = getErrorMessage(error);
+
+  if (
+    message.includes("thinking") &&
+    (message.includes("must start with") ||
+      message.includes("first block") ||
+      message.includes("preceeding") ||
+      message.includes("preceding") ||
+      (message.includes("expected") && message.includes("found")))
+  ) {
+    return "thinking_block_order";
+  }
+
+  return null;
+}
+
+export function isRecoverableError(error: unknown): boolean {
+  return detectErrorType(error) !== null;
+}
+
+const TOAST_TITLES: Record<string, string> = {
+  thinking_block_order: "Thinking Block Recovery",
+};
+
+const TOAST_MESSAGES: Record<string, string> = {
+  thinking_block_order: "Fixing message structure...",
+};
+
+function getRecoveryToastContent(errorType: RecoveryErrorType | null): {
+  title: string;
+  message: string;
+} {
+  if (!errorType) {
+    return {
+      title: "Session Recovery",
+      message: "Attempting to recover session...",
+    };
+  }
+  return {
+    title: TOAST_TITLES[errorType] || "Session Recovery",
+    message: TOAST_MESSAGES[errorType] || "Attempting to recover session...",
+  };
+}
+
+async function recoverThinkingBlockOrder(
+  sessionID: string,
+  _failedMsg: MessageData,
+  error: unknown
+): Promise<boolean> {
+  const targetIndex = extractMessageIndex(error);
+  if (targetIndex !== null) {
+    const targetMessageID = findMessageByIndexNeedingThinking(sessionID, targetIndex);
+    if (targetMessageID) {
+      return prependThinkingPart(sessionID, targetMessageID);
+    }
+  }
+
+  const orphanMessages = findMessagesWithOrphanThinking(sessionID);
+
+  if (orphanMessages.length === 0) {
+    return false;
+  }
+
+  let anySuccess = false;
+  for (const messageID of orphanMessages) {
+    if (prependThinkingPart(sessionID, messageID)) {
+      anySuccess = true;
+    }
+  }
+
+  return anySuccess;
+}
+
+export interface SessionRecoveryHook {
+  handleSessionRecovery: (info: MessageInfo) => Promise<boolean>;
+  isRecoverableError: (error: unknown) => boolean;
+}
+
+export interface SessionRecoveryContext {
+  client: PluginClient;
+  directory: string;
+}
+
+export function createSessionRecoveryHook(
+  ctx: SessionRecoveryContext
+): SessionRecoveryHook | null {
+  const { client, directory } = ctx;
+  const processingErrors = new Set<string>();
+
+  const handleSessionRecovery = async (info: MessageInfo): Promise<boolean> => {
+    if (!info || info.role !== "assistant" || !info.error) return false;
+
+    const errorType = detectErrorType(info.error);
+    if (!errorType) return false;
+
+    const sessionID = info.sessionID;
+    if (!sessionID) return false;
+
+    let assistantMsgID = info.id;
+    let msgs: MessageData[] | undefined;
+
+    log.debug("Recovery attempt started", {
+      errorType,
+      sessionID,
+      providedMsgID: assistantMsgID ?? "none",
+    });
+
+    await client.session.abort({ path: { id: sessionID } }).catch(() => {});
+
+    const messagesResp = await client.session.messages({
+      path: { id: sessionID },
+      query: { directory },
+    });
+    msgs = (messagesResp as { data?: MessageData[] }).data;
+
+    if (!assistantMsgID && msgs && msgs.length > 0) {
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        const m = msgs[i];
+        if (m && m.info?.role === "assistant" && m.info?.id) {
+          assistantMsgID = m.info.id;
+          log.debug("Found assistant message ID from session messages", {
+            msgID: assistantMsgID,
+            msgIndex: i,
+          });
+          break;
+        }
+      }
+    }
+
+    if (!assistantMsgID) {
+      log.debug("No assistant message ID found, cannot recover");
+      return false;
+    }
+    if (processingErrors.has(assistantMsgID)) return false;
+    processingErrors.add(assistantMsgID);
+
+    try {
+      const failedMsg = msgs?.find((m) => m.info?.id === assistantMsgID);
+      if (!failedMsg) {
+        return false;
+      }
+
+      const toastContent = getRecoveryToastContent(errorType);
+      await client.tui
+        .showToast({
+          body: {
+            title: toastContent.title,
+            message: toastContent.message,
+            variant: "warning",
+          },
+        })
+        .catch(() => {});
+
+      let success = false;
+
+      if (errorType === "thinking_block_order") {
+        success = await recoverThinkingBlockOrder(sessionID, failedMsg, info.error);
+      }
+
+      return success;
+    } catch (err) {
+      log.error("Recovery failed", { error: String(err) });
+      return false;
+    } finally {
+      processingErrors.delete(assistantMsgID);
+    }
+  };
+
+  return {
+    handleSessionRecovery,
+    isRecoverableError,
+  };
+}

--- a/src/plugin/recovery/storage.ts
+++ b/src/plugin/recovery/storage.ts
@@ -1,0 +1,251 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { MESSAGE_STORAGE, PART_STORAGE } from "./constants";
+import type { StoredMessageMeta, StoredPart } from "./types";
+
+export function generatePartId(): string {
+  const timestamp = Date.now().toString(16);
+  const random = Math.random().toString(36).substring(2, 10);
+  return `prt_${timestamp}${random}`;
+}
+
+export function getMessageDir(sessionID: string): string {
+  if (!existsSync(MESSAGE_STORAGE)) return "";
+
+  const directPath = join(MESSAGE_STORAGE, sessionID);
+  if (existsSync(directPath)) {
+    return directPath;
+  }
+
+  try {
+    for (const dir of readdirSync(MESSAGE_STORAGE)) {
+      const sessionPath = join(MESSAGE_STORAGE, dir, sessionID);
+      if (existsSync(sessionPath)) {
+        return sessionPath;
+      }
+    }
+  } catch {
+    // Ignore read errors
+  }
+
+  return "";
+}
+
+export function readMessages(sessionID: string): StoredMessageMeta[] {
+  const messageDir = getMessageDir(sessionID);
+  if (!messageDir || !existsSync(messageDir)) return [];
+
+  const messages: StoredMessageMeta[] = [];
+  try {
+    for (const file of readdirSync(messageDir)) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const content = readFileSync(join(messageDir, file), "utf-8");
+        messages.push(JSON.parse(content));
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return messages.sort((a, b) => {
+    const aTime = a.time?.created ?? 0;
+    const bTime = b.time?.created ?? 0;
+    if (aTime !== bTime) return aTime - bTime;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function readParts(messageID: string): StoredPart[] {
+  const partDir = join(PART_STORAGE, messageID);
+  if (!existsSync(partDir)) return [];
+
+  const parts: StoredPart[] = [];
+  try {
+    for (const file of readdirSync(partDir)) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const content = readFileSync(join(partDir, file), "utf-8");
+        parts.push(JSON.parse(content));
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return parts.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function findMessageByIndexNeedingThinking(
+  sessionID: string,
+  targetIndex: number
+): string | null {
+  const messages = readMessages(sessionID);
+  const assistantMessages = messages.filter((m) => m.role === "assistant");
+
+  if (targetIndex >= 0 && targetIndex < assistantMessages.length) {
+    return assistantMessages[targetIndex]?.id ?? null;
+  }
+
+  return null;
+}
+
+export function findMessagesWithOrphanThinking(sessionID: string): string[] {
+  const messageDir = getMessageDir(sessionID);
+  if (!messageDir) return [];
+
+  const orphanMessages: string[] = [];
+
+  try {
+    for (const file of readdirSync(messageDir)) {
+      if (!file.endsWith(".json")) continue;
+
+      try {
+        const content = readFileSync(join(messageDir, file), "utf-8");
+        const meta = JSON.parse(content) as StoredMessageMeta;
+
+        if (meta.role !== "assistant") continue;
+
+        const parts = readParts(meta.id);
+        const hasThinkingPart = parts.some(
+          (p) => p.type === "thinking" || p.type === "redacted_thinking"
+        );
+        const hasReasoningPart = parts.some((p) => p.type === "reasoning");
+
+        if ((hasThinkingPart || hasReasoningPart) && !hasLeadingThinking(parts)) {
+          orphanMessages.push(meta.id);
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return orphanMessages;
+}
+
+function hasLeadingThinking(parts: StoredPart[]): boolean {
+  if (parts.length === 0) return false;
+  const firstPart = parts[0];
+  if (!firstPart) return false;
+  return (
+    firstPart.type === "thinking" ||
+    firstPart.type === "redacted_thinking" ||
+    firstPart.type === "reasoning"
+  );
+}
+
+export function findMessagesWithThinkingBlocks(sessionID: string): string[] {
+  const messageDir = getMessageDir(sessionID);
+  if (!messageDir) return [];
+
+  const messagesWithThinking: string[] = [];
+
+  try {
+    for (const file of readdirSync(messageDir)) {
+      if (!file.endsWith(".json")) continue;
+
+      try {
+        const content = readFileSync(join(messageDir, file), "utf-8");
+        const meta = JSON.parse(content) as StoredMessageMeta;
+
+        const parts = readParts(meta.id);
+        const hasThinking = parts.some(
+          (p) => p.type === "thinking" || p.type === "redacted_thinking" || p.type === "reasoning"
+        );
+
+        if (hasThinking) {
+          messagesWithThinking.push(meta.id);
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return [];
+  }
+
+  return messagesWithThinking;
+}
+
+export function prependThinkingPart(sessionID: string, messageID: string): boolean {
+  const partDir = join(PART_STORAGE, messageID);
+  if (!existsSync(partDir)) {
+    try {
+      mkdirSync(partDir, { recursive: true });
+    } catch {
+      return false;
+    }
+  }
+
+  const parts = readParts(messageID);
+  const alreadyHasThinking = parts.some(
+    (p) => p.type === "thinking" || p.type === "redacted_thinking" || p.type === "reasoning"
+  );
+
+  if (alreadyHasThinking) {
+    return true;
+  }
+
+  const thinkingPart: StoredPart = {
+    id: generatePartId(),
+    sessionID,
+    messageID,
+    type: "thinking",
+    text: "",
+  };
+
+  try {
+    writeFileSync(join(partDir, `${thinkingPart.id}.json`), JSON.stringify(thinkingPart));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function stripThinkingParts(messageID: string): boolean {
+  const partDir = join(PART_STORAGE, messageID);
+  if (!existsSync(partDir)) return false;
+
+  let removed = false;
+
+  try {
+    for (const file of readdirSync(partDir)) {
+      if (!file.endsWith(".json")) continue;
+
+      try {
+        const partPath = join(partDir, file);
+        const content = readFileSync(partPath, "utf-8");
+        const part = JSON.parse(content) as StoredPart;
+
+        if (
+          part.type === "thinking" ||
+          part.type === "redacted_thinking" ||
+          part.type === "reasoning"
+        ) {
+          unlinkSync(partPath);
+          removed = true;
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  return removed;
+}

--- a/src/plugin/recovery/types.ts
+++ b/src/plugin/recovery/types.ts
@@ -1,0 +1,98 @@
+export type ThinkingPartType = "thinking" | "redacted_thinking" | "reasoning";
+export type MetaPartType = "step-start" | "step-finish";
+export type ContentPartType = "text" | "tool" | "tool_use" | "tool_result";
+
+export type RecoveryErrorType = "thinking_block_order";
+
+export interface StoredMessageMeta {
+  id: string;
+  sessionID: string;
+  role: "user" | "assistant";
+  parentID?: string;
+  time?: {
+    created: number;
+    completed?: number;
+  };
+  error?: unknown;
+}
+
+export interface StoredTextPart {
+  id: string;
+  sessionID: string;
+  messageID: string;
+  type: "text";
+  text: string;
+  synthetic?: boolean;
+  ignored?: boolean;
+}
+
+export interface StoredToolPart {
+  id: string;
+  sessionID: string;
+  messageID: string;
+  type: "tool";
+  callID: string;
+  tool: string;
+  state: {
+    status: "pending" | "running" | "completed" | "error";
+    input: Record<string, unknown>;
+    output?: string;
+    error?: string;
+  };
+}
+
+export interface StoredReasoningPart {
+  id: string;
+  sessionID: string;
+  messageID: string;
+  type: "reasoning";
+  text: string;
+}
+
+export interface StoredStepPart {
+  id: string;
+  sessionID: string;
+  messageID: string;
+  type: "step-start" | "step-finish";
+}
+
+export type StoredPart =
+  | StoredTextPart
+  | StoredToolPart
+  | StoredReasoningPart
+  | StoredStepPart
+  | {
+      id: string;
+      sessionID: string;
+      messageID: string;
+      type: string;
+      [key: string]: unknown;
+    };
+
+export interface MessagePart {
+  type: string;
+  id?: string;
+  text?: string;
+  thinking?: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  callID?: string;
+}
+
+export interface MessageData {
+  info?: {
+    id?: string;
+    role?: string;
+    sessionID?: string;
+    parentID?: string;
+    error?: unknown;
+  };
+  parts?: MessagePart[];
+}
+
+export interface MessageInfo {
+  id?: string;
+  role: string;
+  sessionID?: string;
+  error: unknown;
+}

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -38,6 +38,7 @@ export type PluginClient = PluginInput['client'];
 
 export interface PluginContext {
   client: PluginClient;
+  directory: string;
 }
 
 export type PluginResult = Awaited<ReturnType<Plugin>>;


### PR DESCRIPTION
Implements automatic session recovery when thinking block errors occur, allowing users to continue their work without manual intervention.

- Add src/plugin/recovery/ module with storage, types, and recovery logic
- Extend PluginContext to include directory for recovery state persistence
- Integrate recovery hook into plugin event handler
- Recover sessions on recoverable thinking errors with user notification

Closes #23