### PR TITLE
fix: bump user-agent to 1.15.8 and detect OS/arch dynamically

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { platform, arch } from "node:os";
+
 export const ANTIGRAVITY_CLIENT_ID = "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com";
 export const ANTIGRAVITY_CLIENT_SECRET = "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";
 export const ANTIGRAVITY_CALLBACK_PORT = 36742;
@@ -11,7 +13,27 @@ export const ANTIGRAVITY_SCOPES: readonly string[] = [
   "https://www.googleapis.com/auth/experimentsandconfigs",
 ];
 
-export const ANTIGRAVITY_USER_AGENT = "antigravity/1.11.5 windows/amd64";
+/**
+ * Map Node.js os values to Antigravity's expected platform/arch format.
+ * Falls back to "linux/amd64" if the platform or arch is unrecognized.
+ */
+function getAntigravityPlatform(): string {
+  const platformMap: Record<string, string> = {
+    darwin: "darwin",
+    linux: "linux",
+    win32: "windows",
+  };
+  const archMap: Record<string, string> = {
+    arm64: "arm64",
+    x64: "amd64",
+    ia32: "386",
+  };
+  const p = platformMap[platform()] ?? "linux";
+  const a = archMap[arch()] ?? "amd64";
+  return `${p}/${a}`;
+}
+
+export const ANTIGRAVITY_USER_AGENT = `antigravity/1.15.8 ${getAntigravityPlatform()}`;
 export const ANTIGRAVITY_API_CLIENT = "google-cloud-sdk vscode_cloudshelleditor/0.1";
 export const ANTIGRAVITY_CLIENT_METADATA = '{"ideType":"IDE_UNSPECIFIED","platform":"PLATFORM_UNSPECIFIED","pluginType":"GEMINI"}';
 


### PR DESCRIPTION
## Summary
- Bumps Antigravity user-agent version from 1.11.5 to 1.15.8 (fixes Google API rejection)
- Detects platform and architecture dynamically via node:os instead of hardcoding windows/amd64

## What Changed
src/constants.ts - added getAntigravityPlatform() helper that maps os.platform() and os.arch() to Antigravity expected format (e.g. darwin/arm64, linux/amd64, windows/amd64). Falls back to linux/amd64 for unrecognized environments.

## Why
Google API now rejects version 1.11.5. Additionally, hardcoding windows/amd64 sends incorrect platform info for macOS and Linux users. Verified working on macOS ARM64 with gemini-3-flash-preview.

Fixes #32