### PR TITLE
Support Claude 4.6 proxy models

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ Antigravity provides access to Claude models via `gemini-claude-*` model names. 
 - `gemini-claude-sonnet-4-5` - Claude Sonnet 4.5
 - `gemini-claude-sonnet-4-5-thinking` - Claude Sonnet 4.5 with thinking
 - `gemini-claude-opus-4-5-thinking` - Claude Opus 4.5 with thinking
+- `gemini-claude-sonnet-4-6` - Claude Sonnet 4.6
+- `gemini-claude-sonnet-4-6-thinking` - Claude Sonnet 4.6 with thinking
+- `gemini-claude-opus-4-6-thinking` - Claude Opus 4.6 with thinking
 
 ### Interleaved Thinking Support
 
@@ -461,5 +464,4 @@ Turn 5: Switch to Gemini  → Claude's thinking removed, Gemini Turn 3 restored 
 - **No cross-contamination**: Impossible for signatures to leak between families
 - **Conversation text preserved**: Only thinking blocks are removed; actual response text flows through normally
 - **Same-provider continuity**: Each family maintains its own thinking history across model switches
-
 

--- a/src/plugin/request.test.ts
+++ b/src/plugin/request.test.ts
@@ -18,6 +18,23 @@ describe("Interleaved Thinking Headers", () => {
     expect(headers.get("anthropic-beta")).toBe("interleaved-thinking-2025-05-14");
   });
 
+  test("supports Claude 4.6 thinking models (aliases and adds header)", async () => {
+    const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-claude-sonnet-4-6-thinking:streamGenerateContent";
+
+    const result = await prepareAntigravityRequest(
+      url,
+      { method: "POST", body: JSON.stringify({ contents: [] }) },
+      "dummy-token",
+      "dummy-project"
+    );
+
+    const headers = result.init.headers as Headers;
+    expect(headers.get("anthropic-beta")).toBe("interleaved-thinking-2025-05-14");
+
+    const body = JSON.parse(result.init.body as string);
+    expect(body.model).toBe("claude-sonnet-4-6-thinking");
+  });
+
   test("does NOT add header for non-thinking claude models", async () => {
     const url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-claude-sonnet-4-5:streamGenerateContent";
     

--- a/src/plugin/request.ts
+++ b/src/plugin/request.ts
@@ -458,6 +458,13 @@ export function createSseTransformStream(onError?: (body: GeminiApiBody) => Gemi
 
 
 function resolveModelName(rawModel: string): string {
+  // Antigravity exposes Claude via Gemini-style model IDs like:
+  // `gemini-claude-sonnet-4-6-thinking`, but the Code Assist backend expects
+  // `claude-sonnet-4-6-thinking`. Normalize all current/future Claude proxy IDs.
+  if (rawModel.startsWith("gemini-claude-")) {
+    return rawModel.replace(/^gemini-/, "");
+  }
+
   const aliased = MODEL_ALIASES[rawModel];
   if (aliased) {
     return aliased;
@@ -804,4 +811,3 @@ export async function transformAntigravityResponse(
     return response;
   }
 }
-


### PR DESCRIPTION
Normalize gemini-claude-* model IDs to claude-* to support 4.6 and future versions. Adds a unit test and README update.